### PR TITLE
increase maximum number of logs that will be parsed

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -7,7 +7,7 @@
 
 #include "blackbox_fielddefs.h"
 
-#define FLIGHT_LOG_MAX_LOGS_IN_FILE 31
+#define FLIGHT_LOG_MAX_LOGS_IN_FILE 128
 #define FLIGHT_LOG_MAX_FIELDS 128
 #define FLIGHT_LOG_MAX_FRAME_LENGTH 256
 


### PR DESCRIPTION
The default number of logs in a blackbox file is restrictive, I've see examples with many more in log files offered for analysis etc.
This (trivial PR) increases the value to an arbitrary 128.