### PR TITLE
Fix flightModeFlags and stateFlags decode to string

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -546,9 +546,9 @@ void outputSlowFrameFields(flightLog_t *log, int64_t *frame)
                 && options.unitFlags == UNIT_FLAGS) {
 
             if (i == log->slowFieldIndexes.flightModeFlags) {
-                flightlogFlightModeToString(frame[i], buffer, BUFFER_LEN);
+                flightlogFlightModeToString(log, frame[i], buffer, BUFFER_LEN);
             } else {
-                flightlogFlightStateToString(frame[i], buffer, BUFFER_LEN);
+                flightlogFlightStateToString(log, frame[i], buffer, BUFFER_LEN);
             }
 
             fprintf(csvFile, "%s", buffer);

--- a/src/blackbox_fielddefs.c
+++ b/src/blackbox_fielddefs.c
@@ -1,4 +1,5 @@
 #include "blackbox_fielddefs.h"
+#include <stdlib.h>
 
 const char * const FLIGHT_LOG_FLIGHT_MODE_NAME[] = {
     "ANGLE_MODE",
@@ -10,7 +11,93 @@ const char * const FLIGHT_LOG_FLIGHT_MODE_NAME[] = {
     "HEADFREE",
     "AUTOTUNE",
     "PASSTHRU",
-    "SONAR"
+    "SONAR",
+    NULL
+};
+
+const char * const FLIGHT_LOG_FLIGHT_MODE_NAME_BETAFLIGHT[] = {
+    "ARM",
+    "ANGLE",
+    "HORIZON",
+    "MAG",
+    "HEADFREE",
+    "PASSTHRU",
+    "FAILSAFE",
+    "GPSRESCUE",
+    "GPSRESCUE",
+    "ANTIGRAVITY",
+    "HEADADJ",
+    "CAMSTAB",
+    "BEEPERON",
+    "LEDLOW",
+    "CALIB",
+    "OSD",
+    "TELEMETRY",
+    "SERVO1",
+    "SERVO2",
+    "SERVO3",
+    "BLACKBOX",
+    "AIRMODE",
+    "3D",
+    "FPVANGLEMIX",
+    "BLACKBOXERASE",
+    "CAMERA1",
+    "CAMERA2",
+    "CAMERA3",
+    "FLIPOVERAFTERCRASH",
+    "PREARM",
+    "BEEPGPSCOUNT",
+    "VTXPITMODE",
+    "PARALYZE",
+    "USER1",
+    "USER2",
+    "USER3",
+    "USER4",
+    "PIDAUDIO",
+    "ACROTRAINER",
+    "VTXCONTROLDISABLE",
+    "LAUNCHCONTROL",
+    NULL
+};
+
+const char * const FLIGHT_LOG_FLIGHT_MODE_NAME_INAV[] = {
+    "ARM",
+    "ANGLE",
+    "HORIZON",
+    "NAVALTHOLD",
+    "HEADINGHOLD",
+    "HEADFREE",
+    "HEADADJ",
+    "CAMSTAB",
+    "NAVRTH",
+    "NAVPOSHOLD",
+    "MANUAL",
+    "BEEPERON",
+    "LEDLOW",
+    "LIGHTS",
+    "NAVLAUNCH",
+    "OSD",
+    "TELEMETRY",
+    "BLACKBOX",
+    "FAILSAFE",
+    "NAVWP",
+    "AIRMODE",
+    "HOMERESET",
+    "GCSNAV",
+    "KILLSWITCH",
+    "SURFACE",
+    "FLAPERON",
+    "TURNASSIST",
+    "AUTOTRIM",
+    "AUTOTUNE",
+    "CAMERA1",
+    "CAMERA2",
+    "CAMERA3",
+    "OSDALT1",
+    "OSDALT2",
+    "OSDALT3",
+    "NAVCRUISE",
+    NULL
 };
 
 const char * const FLIGHT_LOG_FLIGHT_STATE_NAME[] = {
@@ -18,7 +105,24 @@ const char * const FLIGHT_LOG_FLIGHT_STATE_NAME[] = {
     "GPS_FIX",
     "CALIBRATE_MAG",
     "SMALL_ANGLE",
-    "FIXED_WING"
+    "FIXED_WING",
+    NULL
+};
+
+const char * const FLIGHT_LOG_FLIGHT_STATE_NAME_INAV[] = {
+    "GPS_FIX_HOME",
+    "GPS_FIX",
+    "CALIBRATE_MAG",
+    "SMALL_ANGLE",
+    "FIXED_WING",
+    "ANTI_WINDUP",
+    "FLAPERON_AVAILABLE",
+    "NAV_MOTOR_STOP_OR_IDLE",
+    "COMPASS_CALIBRATED",
+    "ACCELEROMETER_CALIBRATED",
+    "PWM_DRIVER_AVAILABLE",
+    "HELICOPTER",
+    NULL
 };
 
 const char * const FLIGHT_LOG_FAILSAFE_PHASE_NAME[] = {

--- a/src/blackbox_fielddefs.h
+++ b/src/blackbox_fielddefs.h
@@ -95,32 +95,12 @@ typedef enum FlightLogFieldSign {
     FLIGHT_LOG_FIELD_SIGNED   = 1
 } FlightLogFieldSign;
 
-typedef enum {
-    ANGLE_MODE      = (1 << 0),
-    HORIZON_MODE    = (1 << 1),
-    MAG_MODE        = (1 << 2),
-    BARO_MODE       = (1 << 3),
-    GPS_HOME_MODE   = (1 << 4),
-    GPS_HOLD_MODE   = (1 << 5),
-    HEADFREE_MODE   = (1 << 6),
-    AUTOTUNE_MODE   = (1 << 7),
-    PASSTHRU_MODE   = (1 << 8),
-    SONAR_MODE      = (1 << 9),
-} flightModeFlags_e;
-
-#define FLIGHT_LOG_FLIGHT_MODE_COUNT 10
-
 extern const char * const FLIGHT_LOG_FLIGHT_MODE_NAME[];
-
-typedef enum {
-    GPS_FIX_HOME   = (1 << 0),
-    GPS_FIX        = (1 << 1),
-    CALIBRATE_MAG  = (1 << 2),
-    SMALL_ANGLE    = (1 << 3),
-    FIXED_WING     = (1 << 4),                   // set when in flying_wing or airplane mode. currently used by althold selection code
-} stateFlags_t;
+extern const char * const FLIGHT_LOG_FLIGHT_MODE_NAME_BETAFLIGHT[];
+extern const char * const FLIGHT_LOG_FLIGHT_MODE_NAME_INAV[];
 
 extern const char * const FLIGHT_LOG_FLIGHT_STATE_NAME[];
+extern const char * const FLIGHT_LOG_FLIGHT_STATE_NAME_INAV[];
 
 #define FLIGHT_LOG_FLIGHT_STATE_COUNT 5
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -428,6 +428,13 @@ static void parseHeaderLine(flightLog_t *log, mmapStream_t *stream)
             log->sysConfig.firmwareType = FIRMWARE_TYPE_CLEANFLIGHT;
         else
             log->sysConfig.firmwareType = FIRMWARE_TYPE_BASEFLIGHT;
+    } else if (strcmp(fieldName, "Firmware revision") == 0) {
+        if (strncmp(fieldValue, "Betaflight",10) == 0)
+            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_BETAFLIGHT;
+        else if (strncmp(fieldValue, "INAV", 4) == 0)
+            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_INAV;
+        else
+            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_UNKNOWN;
     } else if (strcmp(fieldName, "minthrottle") == 0) {
         log->sysConfig.minthrottle = atoi(fieldValue);
 
@@ -967,7 +974,7 @@ double flightlogGyroToRadiansPerSecond(flightLog_t *log, int32_t gyroRaw)
     return (double)log->sysConfig.gyroScale * 1000000 * gyroRaw;
 }
 
-static void flightlogDecodeFlagsToString(uint32_t flags, int numFlags, const char * const *flagNames, char *dest, unsigned destLen)
+static void flightlogDecodeFlagsToString(uint64_t flags, const char * const *flagNames, char *dest, unsigned destLen)
 {
     bool printedFlag = false;
     const char NO_FLAGS_MESSAGE[] = "0";
@@ -978,8 +985,10 @@ static void flightlogDecodeFlagsToString(uint32_t flags, int numFlags, const cha
         exit(-1);
     }
 
-    for (int i = 0; i < numFlags; i++) {
-        if ((flags & (1 << i)) != 0) {
+    //dest += sprintf(dest, "(0x%016llX) ", flags);
+
+    for (int i = 0; flagNames[i] != NULL; i++) {
+        if ((flags & (1i64 << i)) != 0) {
             const char *flagName = flagNames[i];
             unsigned flagNameLen = strlen(flagName);
 
@@ -1028,14 +1037,29 @@ void flightlogDecodeEnumToString(uint32_t value, unsigned numEnums, const char *
     }
 }
 
-void flightlogFlightModeToString(uint32_t flightMode, char *dest, int destLen)
+void flightlogFlightModeToString(flightLog_t *log, uint64_t flightMode, char *dest, int destLen)
 {
-    flightlogDecodeFlagsToString(flightMode, FLIGHT_LOG_FLIGHT_MODE_COUNT, FLIGHT_LOG_FLIGHT_MODE_NAME, dest, destLen);
+    if (log->sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT)
+    {
+        if (log->sysConfig.firmwareRevison == FIRMWARE_REVISON_INAV)
+            flightlogDecodeFlagsToString(flightMode, FLIGHT_LOG_FLIGHT_MODE_NAME_INAV, dest, destLen);
+        else
+            flightlogDecodeFlagsToString(flightMode, FLIGHT_LOG_FLIGHT_MODE_NAME_BETAFLIGHT, dest, destLen);
+    }
+    else
+        flightlogDecodeFlagsToString(flightMode, FLIGHT_LOG_FLIGHT_MODE_NAME, dest, destLen);
 }
 
-void flightlogFlightStateToString(uint32_t flightState, char *dest, int destLen)
+void flightlogFlightStateToString(flightLog_t *log, uint64_t flightState, char *dest, int destLen)
 {
-    flightlogDecodeFlagsToString(flightState, FLIGHT_LOG_FLIGHT_STATE_COUNT, FLIGHT_LOG_FLIGHT_STATE_NAME, dest, destLen);
+    if (log->sysConfig.firmwareType == FIRMWARE_TYPE_CLEANFLIGHT && log->sysConfig.firmwareRevison == FIRMWARE_REVISON_INAV)
+    {
+        flightlogDecodeFlagsToString(flightState, FLIGHT_LOG_FLIGHT_STATE_NAME, dest, destLen);
+    }
+    else
+    {
+        flightlogDecodeFlagsToString(flightState, FLIGHT_LOG_FLIGHT_STATE_NAME, dest, destLen);
+    }
 }
 
 void flightlogFailsafePhaseToString(uint8_t failsafePhase, char *dest, int destLen)

--- a/src/parser.c
+++ b/src/parser.c
@@ -428,13 +428,6 @@ static void parseHeaderLine(flightLog_t *log, mmapStream_t *stream)
             log->sysConfig.firmwareType = FIRMWARE_TYPE_CLEANFLIGHT;
         else
             log->sysConfig.firmwareType = FIRMWARE_TYPE_BASEFLIGHT;
-    } else if (strcmp(fieldName, "Firmware revision") == 0) {
-        if (strncmp(fieldValue, "Betaflight",10) == 0)
-            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_BETAFLIGHT;
-        else if (strncmp(fieldValue, "INAV", 4) == 0)
-            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_INAV;
-        else
-            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_UNKNOWN;
     } else if (strcmp(fieldName, "minthrottle") == 0) {
         log->sysConfig.minthrottle = atoi(fieldValue);
 
@@ -488,7 +481,9 @@ static void parseHeaderLine(flightLog_t *log, mmapStream_t *stream)
 		log->sysConfig.motorOutputHigh = motorOutputs[1];
     } else if (strcmp(fieldName, "Firmware revision") == 0) {
 
-        if(strncmp(fieldValue, "INAV", 4) == 0) {
+        if (strncmp(fieldValue, "Betaflight", 10) == 0)
+            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_BETAFLIGHT;
+        else if(strncmp(fieldValue, "INAV", 4) == 0) {
             uint8_t major=0,minor=0,micro=0;
             char *ptr = fieldValue+5; // "INAV "
             major = strtol(ptr, &ptr, 10);
@@ -506,7 +501,11 @@ static void parseHeaderLine(flightLog_t *log, mmapStream_t *stream)
                 else
                     log->sysConfig.vbatType = TRANSITIONAL; // needs data check
             }
+            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_INAV;
         }
+        else
+            log->sysConfig.firmwareRevison = FIRMWARE_REVISON_UNKNOWN;
+
     } else if (strcmp(fieldName, "Firmware date") == 0 && log->sysConfig.vbatType == TRANSITIONAL) {
         // This stanz is only necessary for 2.0.0 RC2, RC1 and prior development builds
         int day = atoi(fieldValue+4);
@@ -988,7 +987,7 @@ static void flightlogDecodeFlagsToString(uint64_t flags, const char * const *fla
     //dest += sprintf(dest, "(0x%016llX) ", flags);
 
     for (int i = 0; flagNames[i] != NULL; i++) {
-        if ((flags & (1i64 << i)) != 0) {
+        if ((flags & (1LL << i)) != 0) {
             const char *flagName = flagNames[i];
             unsigned flagNameLen = strlen(flagName);
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -21,8 +21,13 @@ typedef enum FirmwareType {
     FIRMWARE_TYPE_UNKNOWN = 0,
     FIRMWARE_TYPE_BASEFLIGHT,
     FIRMWARE_TYPE_CLEANFLIGHT,
-	FIRMWARE_TYPE_BETAFLIGHT
 } FirmwareType;
+
+typedef enum FirmwareRevison {
+    FIRMWARE_REVISON_UNKNOWN = 0,
+    FIRMWARE_REVISON_BETAFLIGHT,
+    FIRMWARE_REVISON_INAV,
+} FirmwareRevison;
 
 typedef enum VbatType {
     ORIGINAL = 0,
@@ -131,6 +136,7 @@ typedef struct flightLogSysConfig_t {
     uint16_t vbatref;
 
     FirmwareType firmwareType;
+    FirmwareRevison firmwareRevison;
 
     VbatType vbatType;
 } flightLogSysConfig_t;
@@ -183,8 +189,8 @@ unsigned int flightLogVbatADCToMillivolts(flightLog_t *log, uint16_t vbatADC);
 int flightLogAmperageADCToMilliamps(flightLog_t *log, uint16_t amperageADC);
 double flightlogGyroToRadiansPerSecond(flightLog_t *log, int32_t gyroRaw);
 double flightlogAccelerationRawToGs(flightLog_t *log, int32_t accRaw);
-void flightlogFlightModeToString(uint32_t flightMode, char *dest, int destLen);
-void flightlogFlightStateToString(uint32_t flightState, char *dest, int destLen);
+void flightlogFlightModeToString(flightLog_t *log, uint64_t flightMode, char *dest, int destLen);
+void flightlogFlightStateToString(flightLog_t *log, uint64_t flightState, char *dest, int destLen);
 void flightlogFailsafePhaseToString(uint8_t failsafePhase, char *dest, int destLen);
 
 bool flightLogParse(flightLog_t *log, int logIndex, FlightLogMetadataReady onMetadataReady, FlightLogFrameReady onFrameReady, FlightLogEventReady onEvent, bool raw);


### PR DESCRIPTION
The decoding of flightModeFlags was based on the flightModeFlags_e enum, which is not log. In fact, this field is based on the boxId_e enum from rc_modes.h
I added all RC modes for both inav and betaflight and I added the reading of the firmware revision to know from which firmware the log comes from.
I also added the states for both inav and betaflight for the stateFlags field