### PR TITLE
update mAh calculation for inav V2 battery reporting

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -422,10 +422,16 @@ static void updateSimulations(flightLog_t *log, int64_t *frame, int64_t currentT
     }
 
     if (hasAmperageADC) {
+        int currentAmps;
+        if(log->sysConfig.vbatType == INAV_V2)
+            currentAmps = frame[log->mainFieldIndexes.amperageLatest]*10;
+        else
+            currentAmps =  flightLogAmperageADCToMilliamps(log, frame[log->mainFieldIndexes.amperageLatest]);
+
         currentMeterUpdateMeasured(
             &currentMeterMeasured,
-            flightLogAmperageADCToMilliamps(log, frame[log->mainFieldIndexes.amperageLatest]),
-            currentTime
+            currentAmps,
+           currentTime
         );
     }
 
@@ -843,7 +849,7 @@ void applyFieldUnits(flightLog_t *log)
         memset(mainFieldUnit, 0, sizeof(mainFieldUnit));
         memset(gpsGFieldUnit, 0, sizeof(gpsGFieldUnit));
         memset(slowFieldUnit, 0, sizeof(slowFieldUnit));
-    
+
         if (log->mainFieldIndexes.vbatLatest > -1) {
             mainFieldUnit[log->mainFieldIndexes.vbatLatest] = options.unitVbat;
         }

--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -426,7 +426,7 @@ static void updateSimulations(flightLog_t *log, int64_t *frame, int64_t currentT
         if(log->sysConfig.vbatType == INAV_V2)
             currentAmps = frame[log->mainFieldIndexes.amperageLatest]*10;
         else
-            currentAmps =  flightLogAmperageADCToMilliamps(log, frame[log->mainFieldIndexes.amperageLatest]);
+            currentAmps = flightLogAmperageADCToMilliamps(log, frame[log->mainFieldIndexes.amperageLatest]);
 
         currentMeterUpdateMeasured(
             &currentMeterMeasured,


### PR DESCRIPTION
The iNav V2 changes for battery recording (#1) omitted to update the calculation of accumulated current usage.
This PR corrects that. Verified against mwp LTM log (used mAh is now consistent).