### PR TITLE
Add Flight mode column to the CSV file

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -95,13 +95,7 @@ typedef enum {
 	NAV_RTH_MODE = (1 << 8), // old GPS_HOME
 	NAV_POSHOLD_MODE = (1 << 9), // old GPS_HOLD
 	MANUAL_MODE = (1 << 10),
-	NAV_LAUNCH_MODE = (1 << 15),
-	FAILSAFE_MODE = (1 << 19),
-	NAV_WP_MODE = (1 << 20),
-	FLAPERON = (1 << 26),
-	TURN_ASSISTANT = (1 << 27),
-	AUTO_TUNE = (1 << 29), // old G-Tune
-	NAV_CRUISE_MODE = (1 << 36),
+	NAV_WP_MODE = (1 << 19),
 } flightModeFlags_e;
 
 #define FLIGHT_MODE(mask) (flightModeFlags & (mask))
@@ -725,10 +719,6 @@ void outputGPSFields(flightLog_t *log, FILE *file, int64_t *frame)
 
 	// Adding information overlay fields (i.e. Dashware)
 	if (options.mergeGPS) {
-		// rssi (%)
-		fprintf(file, ", %" PRId64, rssiPercent);
-		// Throttle (%)
-		fprintf(file, ", %" PRId64, throttlePercent);
 
 		// Check if home point coordinates has changed by A LOT since the last iteration. It indicates a bogus frame
 		if ( (log->sysConfig.gpsHomeLatitude ) < (gpsHomeLat - 100000) || (log->sysConfig.gpsHomeLatitude) > (gpsHomeLat + 100000 ) 
@@ -918,6 +908,11 @@ void outputMainFrameFields(flightLog_t *log, int64_t frameTime, int64_t *frame)
 
 	// Adding Flight Mode
 	flightModeName(csvFile);
+
+	// rssi (%)
+	fprintf(csvFile, ", %" PRId64, rssiPercent);
+	// Throttle (%)
+	fprintf(csvFile, ", %" PRId64, throttlePercent);
 }
 
 void outputMergeFrame(flightLog_t *log)
@@ -1225,8 +1220,8 @@ void writeMainCSVHeader(flightLog_t *log)
         outputFieldNamesHeader(csvFile, &log->frameDefs['S'], slowFieldUnit, false);
     }
 
-	// Add flight mode header
-	fprintf(csvFile, ", flightMode");
+	// Add flight mode, rssi (%) and Throttle (%) headers
+	fprintf(csvFile, ", flightMode, rssi (%%), Throttle (%%)");
 
     if (options.mergeGPS && log->frameDefs['G'].fieldCount > 0) {
         fprintf(csvFile, ", ");
@@ -1235,7 +1230,7 @@ void writeMainCSVHeader(flightLog_t *log)
     }
 
 	if (options.mergeGPS && log->frameDefs['G'].fieldCount > 0) {
-		fprintf(csvFile, ", rssi (%%), Throttle (%%), Distance (m), homeDirection, mAhPerKm, cumulativeTripDistance, azimuth");
+		fprintf(csvFile, ", Distance (m), homeDirection, mAhPerKm, cumulativeTripDistance, azimuth");
 	}
 
     fprintf(csvFile, "\n");

--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -1221,7 +1221,7 @@ void writeMainCSVHeader(flightLog_t *log)
     }
 
 	// Add flight mode, rssi (%) and Throttle (%) headers
-	fprintf(csvFile, ", flightMode, rssi (%%), Throttle (%%)");
+	fprintf(csvFile, ", simplifiedMode, rssi (%%), Throttle (%%)");
 
     if (options.mergeGPS && log->frameDefs['G'].fieldCount > 0) {
         fprintf(csvFile, ", ");

--- a/src/blackbox_fielddefs.h
+++ b/src/blackbox_fielddefs.h
@@ -192,3 +192,32 @@ typedef struct flightLogEvent_t
     FlightLogEvent event;
     flightLogEventData_t data;
 } flightLogEvent_t;
+
+typedef enum {
+	GPS_FIELD_TYPE_INTEGER,
+	GPS_FIELD_TYPE_DEGREES_TIMES_10, // for headings
+	GPS_FIELD_TYPE_COORDINATE_DEGREES_TIMES_10000000,
+	GPS_FIELD_TYPE_METERS_PER_SECOND_TIMES_100,
+	GPS_FIELD_TYPE_METERS
+} GPSFieldType;
+
+typedef enum {
+	NAV_STATE_CRUISE_2D_IN_PROGRESS = 30,
+	NAV_STATE_CRUISE_2D_ADJUSTING = 31,
+	NAV_STATE_CRUISE_3D_IN_PROGRESS = 33,
+	NAV_STATE_CRUISE_3D_ADJUSTING = 34,
+
+} navigationFSMState_t;
+
+typedef enum {
+	ACRO_MODE = (1 << 0),
+	ANGLE_MODE = (1 << 1),
+	HORIZON_MODE = (1 << 2),
+	NAV_ALTHOLD_MODE = (1 << 3), // old BARO
+	HEADING_MODE = (1 << 4),
+	HEADFREE_MODE = (1 << 5),
+	NAV_RTH_MODE = (1 << 8), // old GPS_HOME
+	NAV_POSHOLD_MODE = (1 << 9), // old GPS_HOLD
+	MANUAL_MODE = (1 << 10),
+	NAV_WP_MODE = (1 << 19),
+} flightModeFlags_e;

--- a/src/parser.c
+++ b/src/parser.c
@@ -246,6 +246,8 @@ static void identifyMainFields(flightLog_t *log, flightLogFrameDef_t *frameDef)
             log->mainFieldIndexes.loopIteration = fieldIndex;
         } else if (strcmp(fieldName, "time") == 0) {
             log->mainFieldIndexes.time = fieldIndex;
+        } else if (strcmp(fieldName, "navState") == 0) {
+            log->mainFieldIndexes.navState = fieldIndex;
         }
     }
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -96,6 +96,7 @@ typedef struct slowFieldIndexes_t {
 typedef struct mainFieldIndexes_t {
     int loopIteration;
     int time;
+	int navState;
 
     int pid[3][3]; //First dimension is [P, I, D], second dimension is axis
 


### PR DESCRIPTION
Add a text column "simplifiedMode" to the CSV file.

It's a 4-character active flight mode indicator, almost identical to the INAV Flight Mode OSD element. 

Possible values are:
* `!FS!`
* `MANU`
* `RTH`
* `A+PH`
* `3CRS`
* `CRS`
* `PH`
* `AH`
* `WP`
* `ANGL`
* `HOR`

It'll be useful to display the active flight mode on a overlay tool that I'm planning to publish soon (a command-line dashware-like tool)

![image](https://user-images.githubusercontent.com/17026744/101648535-ad891380-3a18-11eb-9c6d-d695f8da3b1c.png)

![image](https://user-images.githubusercontent.com/17026744/101649084-415adf80-3a19-11eb-96c4-e61c83ca252b.png)

Also, this change:
* Removes the `--dashware` command line option.
* Makes the fields `Distance (m)`, `homeDirection`, `mAhPerKm`, `cumulativeTripDistance` and `azimuth` available on the CSV file when the `--merge-gps` command line option is used.
* Makes the fields `rssi (%)` and `Throttle (%)` always available, since this fields are not related to GPS data.