### PR TITLE
revert derived geospatial derived data

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1599,13 +1599,11 @@ void flightLogDestroy(flightLog_t *log)
 
 bool getHomeCoordinates(flightLog_t *log, double *lat, double *lon)
 {
-    if (log->private->gpsHomeHistory[1][log->gpsHomeFieldIndexes.GPS_home[0]] != 0 &&
-        log->private->gpsHomeHistory[1][log->gpsHomeFieldIndexes.GPS_home[1]] != 0) {
+    if (log->private->gpsHomeIsValid) {
         *lat = log->private->gpsHomeHistory[0][log->gpsHomeFieldIndexes.GPS_home[0]] / 1e7;
         *lon = log->private->gpsHomeHistory[0][log->gpsHomeFieldIndexes.GPS_home[1]] / 1e7;
-        return true;
     } else {
         *lat = *lon = 0;
-        return false;
     }
+    return log->private->gpsHomeIsValid;
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -97,7 +97,7 @@ typedef struct slowFieldIndexes_t {
 typedef struct mainFieldIndexes_t {
     int loopIteration;
     int time;
-	int navState;
+    int navState;
 
     int pid[3][3]; //First dimension is [P, I, D], second dimension is axis
 
@@ -133,10 +133,6 @@ typedef struct flightLogSysConfig_t {
     uint8_t vbatmaxcellvoltage;
     uint8_t vbatmincellvoltage;
     uint8_t vbatwarningcellvoltage;
-
-	int64_t gpsHomeLatitude;
-	int64_t gpsHomeLongitude;
-
     int16_t currentMeterOffset, currentMeterScale;
 
     uint16_t vbatref;
@@ -203,5 +199,5 @@ void flightlogFailsafePhaseToString(uint8_t failsafePhase, char *dest, int destL
 
 bool flightLogParse(flightLog_t *log, int logIndex, FlightLogMetadataReady onMetadataReady, FlightLogFrameReady onFrameReady, FlightLogEventReady onEvent, bool raw);
 void flightLogDestroy(flightLog_t *log);
-
+bool getHomeCoordinates(flightLog_t *log, double *lat, double *lon);
 #endif


### PR DESCRIPTION
@danarrib, Daniel (you're probably not going to like this). 

As a result of working on the blackbox-tool 0.4.5 series, I've come to the conclusion that geospatial derived data (e.g #19 et al) has no place in the decoded CSV. Rather the CSV should just provide the necessary data for third party applications (like a dashware tool or [bbl2kml](https://github.com/stronnag/bbl2kmltool)) to generate the application specific derived data that the application needs. This means that we don't end up putting 'policy' in the decoded output (for example dealing with your corrupt log with bogus home location data). `blackbox_decode` should not have to decide how to deal with this, it should just report the home location, and the consumer can decide how they deal with it.

Otherwise, the decoder becomes un-maintainable with policy workarounds and unsustainable demands for derived data that can be calculated externally; it's trivially simple to  for a third-party application to spawn `blackbox-decode`, parse the piped CSV and make their own policy decisions (like on the corrupt last three lines of LOG0022.TXT). 
