### PR TITLE
Fix mah calculation

### DIFF
--- a/src/battery.c
+++ b/src/battery.c
@@ -1,5 +1,4 @@
 #include <stdint.h>
-
 #include "battery.h"
 
 #define SECONDS_PER_HOUR 3600u
@@ -15,7 +14,6 @@
 void currentMeterInit(currentMeterState_t *state)
 {
     state->lastTime = 0;
-
     state->energyMilliampHours = 0;
     state->currentMilliamps = 0;
 }
@@ -25,7 +23,7 @@ void currentMeterInit(currentMeterState_t *state)
  *
  * Time is an absolute time in micro-seconds (not a delta).
  */
-void currentMeterUpdateVirtual(currentMeterState_t *state, int16_t currentMeterOffset, int16_t currentMeterScale, uint32_t throttle, uint32_t time)
+void currentMeterUpdateVirtual(currentMeterState_t *state, int16_t currentMeterOffset, int16_t currentMeterScale, uint32_t throttle, uint64_t time)
 {
     int32_t throttleOffset, throttleFactor;
 
@@ -45,13 +43,12 @@ void currentMeterUpdateVirtual(currentMeterState_t *state, int16_t currentMeterO
     state->lastTime = time;
 }
 
-void currentMeterUpdateMeasured(currentMeterState_t *state, int16_t amperageMilliamps, uint32_t time)
+void currentMeterUpdateMeasured(currentMeterState_t *state, int amperageMilliamps, uint64_t time)
 {
     state->currentMilliamps = amperageMilliamps;
 
     if (state->lastTime != 0) {
          state->energyMilliampHours += ((double) state->currentMilliamps * (time - state->lastTime)) / MICROSECONDS_PER_HOUR;
     }
-
     state->lastTime = time;
 }

--- a/src/battery.h
+++ b/src/battery.h
@@ -2,14 +2,14 @@
 #define BATTERY_H_
 
 typedef struct currentMeterState_t {
-    uint32_t lastTime;
+    uint64_t lastTime;
 
     double energyMilliampHours;
     int32_t currentMilliamps;
 } currentMeterState_t;
 
-void currentMeterInit(currentMeterState_t *state);
-void currentMeterUpdateVirtual(currentMeterState_t *state, int16_t currentMeterOffset, int16_t currentMeterScale, uint32_t throttle, uint32_t time);
-void currentMeterUpdateMeasured(currentMeterState_t *state, int16_t amperageMilliamps, uint32_t time);
+extern void currentMeterInit(currentMeterState_t *state);
+extern void currentMeterUpdateVirtual(currentMeterState_t *state, int16_t currentMeterOffset, int16_t currentMeterScale, uint32_t throttle, uint64_t time);
+extern void currentMeterUpdateMeasured(currentMeterState_t *state, int amperageMilliamps, uint64_t time);
 
 #endif

--- a/src/platform.c
+++ b/src/platform.c
@@ -29,10 +29,10 @@
     DWORD WINAPI win32ThreadFuncUnwrap(LPVOID data)
     {
         win32ThreadFuncWrapper_t *unwrapped = (win32ThreadFuncWrapper_t*)data;
-        DWORD result;
+        DWORD result = 0;
 
         //Call the original thread routine with the original data and return that as our result
-        result = (DWORD) (unwrapped->threadFunc(unwrapped->data));
+        /*result = (DWORD)*/ (unwrapped->threadFunc(unwrapped->data));
 
         free(unwrapped);
 


### PR DESCRIPTION
There were a number of legacy integer overflow / truncation issues causing typically -ve mAH energy to be shown. 
This PR addresses such issues.
