### PR TITLE
add "for INAV" to --help / --version output

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -1250,7 +1250,7 @@ int validateLogIndex(flightLog_t *log)
 
 void printVersion(void) {
 #ifdef BLACKBOX_VERSION
-    fputs(STR(BLACKBOX_VERSION) "\n", stdout);
+    fputs(STR(BLACKBOX_VERSION) " (for INAV)\n", stdout);
 #endif
 }
 
@@ -1259,7 +1259,9 @@ void printUsage(const char *argv0)
     fprintf(stderr,
         "Blackbox flight log decoder by Nicholas Sherlock ("
 #ifdef BLACKBOX_VERSION
-            "v" STR(BLACKBOX_VERSION) ", "
+            "v" STR(BLACKBOX_VERSION) " for INAV, "
+#else
+ #warning "BLACKBOX_VERSION is not set"
 #endif
             __DATE__ " " __TIME__ ")\n\n"
         "Usage:\n"

--- a/src/blackbox_render.c
+++ b/src/blackbox_render.c
@@ -1332,7 +1332,9 @@ void printUsage(const char *argv0)
     fprintf(stderr,
         "Blackbox flight log renderer by Nicholas Sherlock ("
 #ifdef BLACKBOX_VERSION
-            "v" STR(BLACKBOX_VERSION) ", "
+            "v" STR(BLACKBOX_VERSION) " for INAV, "
+#else
+ #warning "BLACKBOX_VERSION is not set"
 #endif
             __DATE__ " " __TIME__ ")\n\n"
         "Usage:\n"


### PR DESCRIPTION
## Changes
* Adds "for INAV"  to --help / --version output in order to differentiate from the βF version.
* Adds a noisy preprocessor warning for `BLACKBOX_VERSION` not specified, to remind the maintainer to set this useful information  

## Example output

```
$ blackbox_decode --help
Blackbox flight log decoder by Nicholas Sherlock (v4.0.2-rc1 for INAV, Apr 26 2022 07:43:24)
```
```
$ blackbox_decode --version
4.0.2-rc1 (for INAV)
```

or,  (`BLACKBOX_VERSION` not set at compile time).
 
```
 %% blackbox_decode.c
.//src/blackbox_decode.c: In function ‘printUsage’:
.//src/blackbox_decode.c:1264:3: warning: #warning is a GCC extension
 1264 |  #warning "BLACKBOX_VERSION is not set"
      |   ^~~~~~~
.//src/blackbox_decode.c:1264:3: warning: #warning "BLACKBOX_VERSION is not set" [-Wcpp]
```

Note this is not fatal, the build will complete.