### PR TITLE
rationalise fractional times across platforms

### DIFF
--- a/src/blackbox_decode.c
+++ b/src/blackbox_decode.c
@@ -146,8 +146,8 @@ static void fprintfMilliampsInUnit(FILE *file, int32_t milliamps, Unit unit)
 
 static void fprintfMicrosecondsInUnit(flightLog_t *log, FILE *file, int64_t microseconds, Unit unit)
 {
-    if(log->firsttime == -1) {
-	log->firsttime = microseconds;
+    if(log->gpsStartTime == -1) {
+	log->gpsStartTime = log->sysConfig.logStartTime - microseconds;
     }
 
     switch (unit) {
@@ -1143,7 +1143,8 @@ int decodeFlightLog(flightLog_t *log, const char *filename, int logIndex)
 
     eventFile = NULL;
     eventFilename = NULL;
-    log->firsttime = -1;
+
+    log->gpsStartTime = -1;
 
     if (options.toStdout) {
         csvFile = stdout;

--- a/src/parser.c
+++ b/src/parser.c
@@ -344,7 +344,7 @@ static void identifyFields(flightLog_t * log, uint8_t frameType, flightLogFrameD
     }
 }
 
-static void get_utc_time(char *str, struct timeval *tv) {
+static int64_t get_utc_time(char *str) {
     struct tm tm = {0};
     double fracsec;
     char *ep = NULL;
@@ -373,8 +373,11 @@ static void get_utc_time(char *str, struct timeval *tv) {
 	    break;
 	}
     }
-    tv->tv_sec = mktime(&tm) - gmoff;
-    tv-> tv_usec = (fracsec-(int)fracsec)*1000000;
+    int64_t utime = mktime(&tm) - gmoff;
+    utime *= US_PER_SEC;
+    int64_t usec = (fracsec-(int)fracsec)*US_PER_SEC;
+    utime += usec;
+    return utime;
 }
 
 static void parseHeaderLine(flightLog_t *log, mmapStream_t *stream)
@@ -567,7 +570,7 @@ static void parseHeaderLine(flightLog_t *log, mmapStream_t *stream)
         }
     }
     else if (strcmp(fieldName, "Log start datetime") == 0) {
-	get_utc_time(fieldValue, &log->sysConfig.logStartTime);
+	log->sysConfig.logStartTime = get_utc_time(fieldValue);
     }
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -153,7 +153,7 @@ typedef struct flightLogSysConfig_t {
 
     VbatType vbatType;
 
-    struct timeval logStartTime;
+    int64_t logStartTime;
     ParserMetaData metafound;
 } flightLogSysConfig_t;
 
@@ -191,7 +191,7 @@ typedef struct flightLog_t {
     slowFieldIndexes_t slowFieldIndexes;
 
     struct flightLogPrivate_t *private;
-    int64_t firsttime;
+    int64_t gpsStartTime;
 } flightLog_t;
 
 typedef void (*FlightLogMetadataReady)(flightLog_t *log);

--- a/src/platform.h
+++ b/src/platform.h
@@ -2,6 +2,7 @@
 #define PLATFORM_H_
 
 #include <stdbool.h>
+
 #include "parser.h"
 
 #if defined(__APPLE__)
@@ -69,4 +70,8 @@ bool directory_create(const char *name);
 
 void platform_init(void);
 extern char *format_gps_timez(flightLog_t *, int64_t, char *, size_t);
+
+#define US_PER_SEC 1000000
+
+
 #endif


### PR DESCRIPTION
Minimise platform specific code. Use `int64_t` for elapsed time since arming rather than `timeval` to simplify incremental updates.
